### PR TITLE
Fix: 크롤링 URL 중복 검증 요청 시, URL 값으로만 검증되도록 수정

### DIFF
--- a/src/main/java/com/cmc/suppin/event/crawl/controller/CrawlApi.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/controller/CrawlApi.java
@@ -33,8 +33,8 @@ public class CrawlApi {
                     "Response<br>" +
                     "- 요청된 URL과 중복된 댓글 수집 이력이 있을 경우 '검증 및 확인되었습니다.' 출력<br>" +
                     "- 요청된 URL과 중복된 댓글 수집 이력이 없을 경우 '수집 이력이 없습니다.' 출력")
-    public ResponseEntity<ApiResponse<String>> checkExistingComments(@RequestParam String url, @RequestParam Long eventId, @CurrentAccount Account account) {
-        String message = crawlService.checkExistingComments(url, eventId, account.userId());
+    public ResponseEntity<ApiResponse<String>> checkExistingComments(@RequestParam String url, @CurrentAccount Account account) {
+        String message = crawlService.checkExistingComments(url, account.userId());
         if (message != null) {
             return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, message));
         }

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
@@ -39,14 +39,11 @@ public class CrawlService {
     private final EventRepository eventRepository;
     private final MemberRepository memberRepository;
 
-    public String checkExistingComments(String url, Long eventId, String userId) {
+    public String checkExistingComments(String url, String userId) {
         Member member = memberRepository.findByUserIdAndStatusNot(userId, UserStatus.DELETED)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
 
-        Event event = eventRepository.findByIdAndMemberId(eventId, member.getId())
-                .orElseThrow(() -> new IllegalArgumentException("Event not found"));
-
-        List<Comment> existingComments = commentRepository.findByUrlAndEventId(url, eventId);
+        List<Comment> existingComments = commentRepository.findByUrl(url);
         if (!existingComments.isEmpty()) {
             LocalDateTime firstCommentDate = existingComments.get(0).getCreatedAt();
             return "동일한 URL의 댓글을 " + firstCommentDate.toLocalDate() + " 일자에 수집한 이력이 있습니다.";


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
크롤링 URL 중복 검증 요청 시, URL 값으로만 검증되도록 수정

## ⏳ 작업 내용
- [x] 크롤링 중복 검증 API 요청 파라미터 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->

