### PR TITLE
Refactor/39: 이벤트 관련 API 리팩토링-1

### DIFF
--- a/src/main/java/com/cmc/suppin/event/crawl/controller/dto/CrawlResponseDTO.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/controller/dto/CrawlResponseDTO.java
@@ -12,7 +12,7 @@ public class CrawlResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CrawlResultDTO {
-        private String crawlingDate;
+        private String crawlTime;
         private int totalCommentCount;
     }
 }

--- a/src/main/java/com/cmc/suppin/event/crawl/converter/CommentConverter.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/converter/CommentConverter.java
@@ -60,7 +60,7 @@ public class CommentConverter {
 
     public static CrawlResponseDTO.CrawlResultDTO toCrawlResultDTO(LocalDateTime crawlingDate, int totalCommentCount) {
         return CrawlResponseDTO.CrawlResultDTO.builder()
-                .crawlingDate(crawlingDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .crawlTime(crawlingDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
                 .totalCommentCount(totalCommentCount)
                 .build();
     }

--- a/src/main/java/com/cmc/suppin/event/crawl/domain/Comment.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/domain/Comment.java
@@ -38,4 +38,11 @@ public class Comment extends BaseDateTimeEntity {
     @Column(nullable = false)
     private LocalDateTime commentDate;
 
+    @Column(nullable = false)
+    private LocalDateTime crawlTime;
+
+    public void setCrawlTime(LocalDateTime crawlTime) {
+        this.crawlTime = crawlTime;
+    }
+
 }

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CommentService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CommentService.java
@@ -48,7 +48,7 @@ public class CommentService {
 
         int totalComments = commentRepository.countByEventIdAndUrl(eventId, url);
 
-        String crawlTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy. MM. dd HH:mm"));
+        String crawlTime = comments.isEmpty() ? "" : comments.getContent().get(0).getCrawlTime().format(DateTimeFormatter.ofPattern("yyyy. MM. dd HH:mm"));
 
         return CommentConverter.toCommentListDTO(comments.getContent(), crawlTime, totalComments);
     }

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
@@ -118,6 +118,8 @@ public class CrawlService {
 
                 currentCommentCount = comments.size();
 
+                LocalDateTime crawlTime = LocalDateTime.now();
+
                 for (Element commentElement : comments) {
                     String author = commentElement.select("#author-text span").text();
                     String text = commentElement.select("#content yt-attributed-string#content-text").text();
@@ -129,6 +131,7 @@ public class CrawlService {
                         // 엔티티 저장
                         LocalDateTime actualCommentDate = DateConverter.convertRelativeTime(time);
                         Comment comment = CommentConverter.toCommentEntity(author, text, actualCommentDate, url, event);
+                        comment.setCrawlTime(crawlTime);
                         commentRepository.save(comment);
                     }
                 }
@@ -137,7 +140,6 @@ public class CrawlService {
                 if (currentCommentCount == previousCommentCount) {
                     break; // 새로운 댓글이 로드되지 않으면 루프를 종료합니다.
                 }
-
                 previousCommentCount = currentCommentCount;
             }
         } catch (InterruptedException e) {

--- a/src/main/java/com/cmc/suppin/event/events/controller/dto/EventResponseDTO.java
+++ b/src/main/java/com/cmc/suppin/event/events/controller/dto/EventResponseDTO.java
@@ -26,7 +26,8 @@ public class EventResponseDTO {
         private Integer surveyCount;
         private Integer commentCount;
         private EventStatus status;
-
+        private Long surveyId;
+        private String uuid;
     }
 
     @Builder

--- a/src/main/java/com/cmc/suppin/event/events/converter/EventConverter.java
+++ b/src/main/java/com/cmc/suppin/event/events/converter/EventConverter.java
@@ -3,6 +3,7 @@ package com.cmc.suppin.event.events.converter;
 import com.cmc.suppin.event.events.controller.dto.EventRequestDTO;
 import com.cmc.suppin.event.events.controller.dto.EventResponseDTO;
 import com.cmc.suppin.event.events.domain.Event;
+import com.cmc.suppin.event.survey.domain.Survey;
 import com.cmc.suppin.global.enums.EventType;
 import com.cmc.suppin.member.domain.Member;
 
@@ -64,6 +65,11 @@ public class EventConverter {
                 .mapToInt(survey -> survey.getAnonymousParticipantList().size())
                 .sum();
 
+        // 이벤트에 설문이 존재하는 경우 surveyId와 uuid 값을 설정
+        Survey survey = event.getSurveyList().stream().findFirst().orElse(null);
+        Long surveyId = (survey != null) ? survey.getId() : null;
+        String uuid = (survey != null) ? survey.getUuid() : null;
+
         return EventResponseDTO.EventInfoDTO.builder()
                 .eventId(event.getId())
                 .type(event.getType())
@@ -75,6 +81,8 @@ public class EventConverter {
                 .surveyCount(surveyAnswerCount)
                 .commentCount(event.getCommentList().size())
                 .status(event.getStatus())
+                .surveyId(surveyId)
+                .uuid(uuid)
                 .build();
     }
 

--- a/src/main/java/com/cmc/suppin/event/survey/controller/SurveyApi.java
+++ b/src/main/java/com/cmc/suppin/event/survey/controller/SurveyApi.java
@@ -34,10 +34,24 @@ public class SurveyApi {
         return ResponseEntity.ok(ApiResponse.of(response));
     }
 
-    @GetMapping("/{surveyId}")
-    @Operation(summary = "설문지 조회 API", description = "생성된 설문지 전체 정보를 조회합니다. 자세한 요청 및 응답 형식은 노션 API 문서를 참고해주세요.")
-    public ResponseEntity<ApiResponse<SurveyResponseDTO.SurveyResultDTO>> getSurvey(@PathVariable("surveyId") Long surveyId) {
-        SurveyResponseDTO.SurveyResultDTO response = surveyService.getSurvey(surveyId);
+    @GetMapping("/view")
+    @Operation(summary = "설문지 조회 API", description = "생성된 설문지 전체 정보를 조회합니다. surveyId와 uuid, 둘 중 하나로 요청할 수 있습니다.")
+    public ResponseEntity<ApiResponse<SurveyResponseDTO.SurveyResultDTO>> getSurvey(
+            @Parameter(description = "required = false")
+            @RequestParam(value = "surveyId", required = false) Long surveyId,
+            @Parameter(description = "required = false")
+            @RequestParam(value = "uuid", required = false) String uuid) {
+
+        SurveyResponseDTO.SurveyResultDTO response;
+
+        if (uuid != null) {
+            response = surveyService.getSurveyByUuid(uuid);
+        } else if (surveyId != null) {
+            response = surveyService.getSurvey(surveyId);
+        } else {
+            throw new IllegalArgumentException("Either surveyId or uuid must be provided");
+        }
+
         return ResponseEntity.ok(ApiResponse.of(response));
     }
 

--- a/src/main/java/com/cmc/suppin/event/survey/domain/repository/SurveyRepository.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/repository/SurveyRepository.java
@@ -3,7 +3,8 @@ package com.cmc.suppin.event.survey.domain.repository;
 import com.cmc.suppin.event.survey.domain.Survey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
-
-
+    Optional<Survey> findByUuid(String uuid);
 }

--- a/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
+++ b/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
@@ -92,6 +92,15 @@ public class SurveyService {
         return SurveyConverter.toSurveyResultDTO(survey, event);
     }
 
+    @Transactional(readOnly = true)
+    public SurveyResponseDTO.SurveyResultDTO getSurveyByUuid(String uuid) {
+        Survey survey = surveyRepository.findByUuid(uuid)
+                .orElseThrow(() -> new IllegalArgumentException("Survey not found for UUID: " + uuid));
+
+        Event event = survey.getEvent();
+        return SurveyConverter.toSurveyResultDTO(survey, event);
+    }
+
     // 설문 응답 저장
     @Transactional
     public void saveSurveyAnswers(SurveyRequestDTO.SurveyAnswerDTO request) {

--- a/src/main/java/com/cmc/suppin/global/security/config/WebMvcConfig.java
+++ b/src/main/java/com/cmc/suppin/global/security/config/WebMvcConfig.java
@@ -39,7 +39,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 "https://api.suppin.store",
                 "https://suppin.store",
                 "http://192.168.200.120:3000",  // 테스트 디바이스 IP 허용
-                "https://coherent-midge-probably.ngrok-free.app"
+                "https://coherent-midge-probably.ngrok-free.app",
+                "https://suppin-servey.vercel.app/"
         ).toArray(String[]::new);
     }
 }

--- a/src/main/java/com/cmc/suppin/global/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/cmc/suppin/global/security/config/WebSecurityConfig.java
@@ -122,6 +122,7 @@ public class WebSecurityConfig {
                 antMatcher("/api/v1/members/join/**"),
                 antMatcher("/api/v1/members/checkUserId"),
                 antMatcher("/api/v1/members/checkEmail"),
+                antMatcher("/api/v1/survey/view/**"),
                 antMatcher("/api/v1/survey/reply/**")   // 설문조사 응답 시 적용
         );
         return requestMatchers.toArray(RequestMatcher[]::new);


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
이벤트 관련 API 리팩토링-1

## ⏳ 작업 내용
1. 크롤링된 전체 댓글 조회 API 응답 시간 수정
2. 익명참가자가 설문 응답하려할 때, 해당 링크의 설문지 조회 API 추가 구현(요청 : uuid 응답: 해당 설문 내용)
3. 이벤트 전체 조회시, 설문 이벤트면 해당 설문의 surveyId값과 uuid 값도 함께 반환

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
당첨자 관리 부분은 기획 회의 후, 추가 설계 고려
