### PR TITLE
Refactor/39: 이벤트 관련 API 리팩토링-2

### DIFF
--- a/src/main/java/com/cmc/suppin/event/crawl/controller/CommentApi.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/controller/CommentApi.java
@@ -44,7 +44,7 @@ public class CommentApi {
     }
 
     @PostMapping("/draft-winners")
-    @Operation(summary = "조건별 당첨자 추첨 API(댓글 이벤트)", description = "주어진 조건에 따라 이벤트의 당첨자를 추첨합니다.")
+    @Operation(summary = "당첨자 랜덤 추첨 결과 리스트 조회 API(댓글 이벤트)", description = "주어진 조건에 따라 이벤트의 당첨자를 추첨합니다.")
     public ResponseEntity<ApiResponse<CommentResponseDTO.WinnerResponseDTO>> drawWinners(
             @RequestBody @Valid CommentRequestDTO.WinnerRequestDTO request,
             @CurrentAccount Account account) {

--- a/src/main/java/com/cmc/suppin/event/crawl/controller/dto/CommentResponseDTO.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/controller/dto/CommentResponseDTO.java
@@ -41,4 +41,14 @@ public class CommentResponseDTO {
         private String endDate;
         private List<CommentDetailDTO> winners;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CommentEventWinners {
+        private String author;
+        private String commentText;
+        private String commentDate;
+    }
 }

--- a/src/main/java/com/cmc/suppin/event/crawl/converter/CommentConverter.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/converter/CommentConverter.java
@@ -64,5 +64,13 @@ public class CommentConverter {
                 .totalCommentCount(totalCommentCount)
                 .build();
     }
+
+    public static CommentResponseDTO.CommentEventWinners toCommentEventWinners(Comment comment) {
+        return CommentResponseDTO.CommentEventWinners.builder()
+                .author(comment.getAuthor())
+                .commentText(comment.getCommentText())
+                .commentDate(comment.getCommentDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .build();
+    }
 }
 

--- a/src/main/java/com/cmc/suppin/event/crawl/domain/Comment.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/domain/Comment.java
@@ -41,8 +41,16 @@ public class Comment extends BaseDateTimeEntity {
     @Column(nullable = false)
     private LocalDateTime crawlTime;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isWinner = false;
+
     public void setCrawlTime(LocalDateTime crawlTime) {
         this.crawlTime = crawlTime;
+    }
+
+    public void setIsWinner(boolean isWinner) {
+        this.isWinner = isWinner;
     }
 
 }

--- a/src/main/java/com/cmc/suppin/event/crawl/domain/repository/CommentRepository.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/domain/repository/CommentRepository.java
@@ -24,4 +24,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByEventIdAndCommentDateBetween(Long eventId, LocalDateTime start, LocalDateTime end);
 
     List<Comment> findByEventIdAndCommentTextContaining(Long eventId, String keyword);
+
+    List<Comment> findByEventIdAndIsWinnerTrue(Long eventId);
 }

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CommentService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CommentService.java
@@ -109,4 +109,15 @@ public class CommentService {
                 .collect(Collectors.toList());
     }
 
+    public List<CommentResponseDTO.CommentEventWinners> getCommentEventWinners(Long eventId, String userId) {
+        Member member = memberRepository.findByUserIdAndStatusNot(userId, UserStatus.DELETED)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        List<Comment> winners = commentRepository.findByEventIdAndIsWinnerTrue(eventId);
+
+        return winners.stream()
+                .map(CommentConverter::toCommentEventWinners)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CommentService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CommentService.java
@@ -54,6 +54,7 @@ public class CommentService {
     }
 
     // 당첨자 조건별 랜덤 추첨(댓글 이벤트)
+    @Transactional
     public CommentResponseDTO.WinnerResponseDTO drawWinners(CommentRequestDTO.WinnerRequestDTO request, String userId) {
         Member member = memberRepository.findByUserIdAndStatusNot(userId, UserStatus.DELETED)
                 .orElseThrow(() -> new IllegalArgumentException("Member not found"));
@@ -76,6 +77,12 @@ public class CommentService {
         // 랜덤 추첨
         Collections.shuffle(filteredComments);
         List<Comment> winners = filteredComments.stream().limit(request.getWinnerCount()).collect(Collectors.toList());
+
+        // 당첨된 댓글의 isWinner 값을 true로 업데이트
+        winners.forEach(winner -> {
+            winner.setIsWinner(true);
+            commentRepository.save(winner);  // 업데이트된 Comment 엔티티를 저장
+        });
 
         return CommentConverter.toWinnerResponseDTO(winners, request);
     }

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
@@ -65,10 +65,14 @@ public class CrawlService {
         if (forceUpdate) {
             // 기존 댓글 삭제
             commentRepository.deleteByUrlAndEventId(url, eventId);
+
+            // 삭제 후, 확인을 위한 로그 출력 또는 추가 검증
+            List<Comment> deletedComments = commentRepository.findByUrlAndEventId(url, eventId);
+            if (!deletedComments.isEmpty()) {
+                throw new RuntimeException("기존 댓글 삭제에 실패했습니다.");
+            }
         } else {
             // 기존 댓글이 존재하는 경우: 크롤링을 중지하고 예외를 던집니다.
-            // 기존 댓글이 존재하지 않는 경우: 새로운 댓글을 크롤링하고 이를 DB에 저장합니다.
-
             List<Comment> existingComments = commentRepository.findByUrlAndEventId(url, eventId);
             if (!existingComments.isEmpty()) {
                 throw new CrawlException(CrawlErrorCode.DUPLICATE_URL);
@@ -112,7 +116,7 @@ public class CrawlService {
             while (System.currentTimeMillis() < endTime) {
                 jsExecutor.executeScript("window.scrollTo(0, document.documentElement.scrollHeight);");
 
-                Thread.sleep(1000); // 1초 대기
+                Thread.sleep(3000); // 3초 대기
 
                 String pageSource = driver.getPageSource();
                 Document doc = Jsoup.parse(pageSource);
@@ -151,5 +155,6 @@ public class CrawlService {
         }
         return CommentConverter.toCrawlResultDTO(LocalDateTime.now(), uniqueComments.size());
     }
+
 }
 

--- a/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
+++ b/src/main/java/com/cmc/suppin/event/crawl/service/CrawlService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,8 +47,9 @@ public class CrawlService {
 
         List<Comment> existingComments = commentRepository.findByUrl(url);
         if (!existingComments.isEmpty()) {
-            LocalDateTime firstCommentDate = existingComments.get(0).getCreatedAt();
-            return "동일한 URL의 댓글을 " + firstCommentDate.toLocalDate() + " 일자에 수집한 이력이 있습니다.";
+            LocalDateTime firstCommentDate = existingComments.get(0).getCrawlTime();
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            return "동일한 URL의 댓글을 " + firstCommentDate.format(formatter) + " 일자에 수집한 이력이 있습니다.";
         }
 
         return null;

--- a/src/main/java/com/cmc/suppin/event/events/controller/EventApi.java
+++ b/src/main/java/com/cmc/suppin/event/events/controller/EventApi.java
@@ -1,10 +1,14 @@
 package com.cmc.suppin.event.events.controller;
 
+import com.cmc.suppin.event.crawl.controller.dto.CommentResponseDTO;
+import com.cmc.suppin.event.crawl.service.CommentService;
 import com.cmc.suppin.event.events.controller.dto.EventRequestDTO;
 import com.cmc.suppin.event.events.controller.dto.EventResponseDTO;
 import com.cmc.suppin.event.events.converter.EventConverter;
 import com.cmc.suppin.event.events.domain.Event;
 import com.cmc.suppin.event.events.service.EventService;
+import com.cmc.suppin.event.survey.controller.dto.SurveyResponseDTO;
+import com.cmc.suppin.event.survey.service.SurveyService;
 import com.cmc.suppin.global.response.ApiResponse;
 import com.cmc.suppin.global.response.ResponseCode;
 import com.cmc.suppin.global.security.reslover.Account;
@@ -29,6 +33,8 @@ import java.util.List;
 public class EventApi {
 
     private final EventService eventService;
+    private final CommentService commentService;
+    private final SurveyService surveyService;
 
     @GetMapping("/all")
     @Operation(summary = "전체 이벤트 조회 API", description = "사용자의 모든 이벤트와 설문 및 댓글 수를 조회합니다.")
@@ -65,5 +71,25 @@ public class EventApi {
     public ResponseEntity<ApiResponse<Void>> deleteEvent(@PathVariable("eventId") Long eventId, @CurrentAccount Account account) {
         eventService.deleteEvent(eventId, account.userId());
         return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS));
+    }
+
+    @GetMapping("/comment-winners")
+    @Operation(summary = "댓글 이벤트 당첨자 조회 API", description = "댓글 이벤트의 당첨자 리스트를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<CommentResponseDTO.CommentEventWinners>>> getCommentEventWinners(
+            @RequestParam("eventId") Long eventId,
+            @CurrentAccount Account account) {
+
+        List<CommentResponseDTO.CommentEventWinners> winners = commentService.getCommentEventWinners(eventId, account.userId());
+        return ResponseEntity.ok(ApiResponse.of(winners));
+    }
+
+    @GetMapping("/survey-winners")
+    @Operation(summary = "설문 이벤트 당첨자 조회 API", description = "설문 이벤트의 당첨자 리스트를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<SurveyResponseDTO.SurveyEventWinners>>> getSurveyEventWinners(
+            @RequestParam("surveyId") Long surveyId,
+            @CurrentAccount Account account) {
+
+        List<SurveyResponseDTO.SurveyEventWinners> winners = surveyService.getSurveyEventWinners(surveyId, account.userId());
+        return ResponseEntity.ok(ApiResponse.of(winners));
     }
 }

--- a/src/main/java/com/cmc/suppin/event/survey/controller/SurveyApi.java
+++ b/src/main/java/com/cmc/suppin/event/survey/controller/SurveyApi.java
@@ -47,7 +47,7 @@ public class SurveyApi {
         if (uuid != null) {
             response = surveyService.getSurveyByUuid(uuid);
         } else if (surveyId != null) {
-            response = surveyService.getSurvey(surveyId);
+            response = surveyService.getSurveyBySurveyId(surveyId);
         } else {
             throw new IllegalArgumentException("Either surveyId or uuid must be provided");
         }

--- a/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyRequestDTO.java
+++ b/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyRequestDTO.java
@@ -22,6 +22,7 @@ public class SurveyRequestDTO {
     public static class SurveyCreateDTO {
         @NotNull
         private Long eventId;
+        private String consentFormHtml; // 개인정보 수집 동의서 HTML 필드
         private List<PersonalInfoOptionDTO> personalInfoOptionList;
         private List<QuestionDTO> questionList;
 

--- a/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyRequestDTO.java
+++ b/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyRequestDTO.java
@@ -4,12 +4,12 @@ import com.cmc.suppin.global.enums.QuestionType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public class SurveyRequestDTO {
@@ -108,9 +108,11 @@ public class SurveyRequestDTO {
         @NotNull
         private Integer winnerCount;
         @NotNull
-        private LocalDateTime startDate;
+        @Pattern(regexp = "\\d{4}\\. \\d{2}\\. \\d{2} \\d{2}:\\d{2}", message = "날짜 형식은 yyyy. MM. dd HH:mm 이어야 합니다.")
+        private String startDate;
         @NotNull
-        private LocalDateTime endDate;
+        @Pattern(regexp = "\\d{4}\\. \\d{2}\\. \\d{2} \\d{2}:\\d{2}", message = "날짜 형식은 yyyy. MM. dd HH:mm 이어야 합니다.")
+        private String endDate;
         @NotNull
         private Integer minLength;
         @NotNull

--- a/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyResponseDTO.java
+++ b/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyResponseDTO.java
@@ -31,6 +31,7 @@ public class SurveyResponseDTO {
         private String startDate;
         private String endDate;
         private String announcementDate;
+        private String consentFormHtml;
         private List<PersonalInfoOptionDTO> personalInfoOptions;
         private List<QuestionDTO> questions;
 

--- a/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyResponseDTO.java
+++ b/src/main/java/com/cmc/suppin/event/survey/controller/dto/SurveyResponseDTO.java
@@ -129,4 +129,14 @@ public class SurveyResponseDTO {
             private List<String> selectedOptions; // 객관식 질문의 경우 선택된 옵션 리스트
         }
     }
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SurveyEventWinners {
+        private String name;
+        private List<WinnerDetailDTO.AnswerDetailDTO> answers;
+    }
 }

--- a/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
+++ b/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
@@ -69,10 +69,12 @@ public class SurveyConverter {
                 .startDate(event.getStartDate().toString())
                 .endDate(event.getEndDate().toString())
                 .announcementDate(event.getAnnouncementDate().toString())
+                .consentFormHtml(survey.getConsentFormHtml())
                 .personalInfoOptions(personalInfoOptions)
                 .questions(questions)
                 .build();
     }
+
 
     public static SurveyResponseDTO.SurveyAnswerResultDTO toSurveyAnswerResultDTO(Question question, Page<Answer> answersPage) {
         List<SurveyResponseDTO.SurveyAnswerResultDTO.AnswerDTO> answers = answersPage.stream()

--- a/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
+++ b/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
@@ -11,10 +11,11 @@ import java.util.stream.Collectors;
 
 public class SurveyConverter {
 
-    public static Survey toSurveyEntity(Event event, String uuid) {
+    public static Survey toSurveyEntity(Event event, String uuid, String consentFormHtml) {
         return Survey.builder()
                 .event(event)
                 .uuid(uuid)
+                .consentFormHtml(consentFormHtml)
                 .build();
     }
 

--- a/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
+++ b/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
@@ -6,6 +6,8 @@ import com.cmc.suppin.event.survey.controller.dto.SurveyResponseDTO;
 import com.cmc.suppin.event.survey.domain.*;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -123,10 +125,12 @@ public class SurveyConverter {
     }
 
     public static SurveyResponseDTO.RandomSelectionResponseDTO.SelectionCriteriaDTO toSelectionCriteriaDTO(SurveyRequestDTO.RandomSelectionRequestDTO request) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd HH:mm");
+
         return SurveyResponseDTO.RandomSelectionResponseDTO.SelectionCriteriaDTO.builder()
                 .winnerCount(request.getWinnerCount())
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
+                .startDate(LocalDateTime.parse(request.getStartDate(), formatter))
+                .endDate(LocalDateTime.parse(request.getEndDate(), formatter))
                 .minLength(request.getMinLength())
                 .keywords(request.getKeywords())
                 .build();

--- a/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
+++ b/src/main/java/com/cmc/suppin/event/survey/converter/SurveyConverter.java
@@ -161,4 +161,20 @@ public class SurveyConverter {
                 .answers(answers)
                 .build();
     }
+
+    public static SurveyResponseDTO.SurveyEventWinners toSurveyEventWinners(AnonymousParticipant participant) {
+        return SurveyResponseDTO.SurveyEventWinners.builder()
+                .name(participant.getName())
+                .answers(participant.getAnswerList().stream()
+                        .map(answer -> SurveyResponseDTO.WinnerDetailDTO.AnswerDetailDTO.builder()
+                                .questionText(answer.getQuestion().getQuestionText())
+                                .answerText(answer.getAnswerText())
+                                .selectedOptions(answer.getAnswerOptionList().stream()
+                                        .map(answerOption -> answerOption.getQuestionOption().getOptionText())
+                                        .collect(Collectors.toList()))
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
 }

--- a/src/main/java/com/cmc/suppin/event/survey/domain/AnonymousParticipant.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/AnonymousParticipant.java
@@ -25,6 +25,7 @@ public class AnonymousParticipant extends BaseDateTimeEntity {
     private Survey survey;
 
     @OneToMany(mappedBy = "anonymousParticipant")
+    @Builder.Default
     private List<Answer> answerList = new ArrayList<>();
 
     private String name;

--- a/src/main/java/com/cmc/suppin/event/survey/domain/AnonymousParticipant.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/AnonymousParticipant.java
@@ -42,11 +42,19 @@ public class AnonymousParticipant extends BaseDateTimeEntity {
     @Column(nullable = false)
     private Boolean isAgreed;
 
-    private Boolean isWinner;
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isWinner = false;
 
-    private Boolean isChecked;
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isChecked = false;
 
     public void setIsWinner(Boolean isWinner) {
         this.isWinner = isWinner;
+    }
+
+    public void setIsChecked(Boolean isChecked) {
+        this.isChecked = isChecked;
     }
 }

--- a/src/main/java/com/cmc/suppin/event/survey/domain/Answer.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/Answer.java
@@ -30,6 +30,7 @@ public class Answer extends BaseDateTimeEntity {
     private AnonymousParticipant anonymousParticipant;
 
     @OneToMany(mappedBy = "answer")
+    @Builder.Default
     private List<AnswerOption> answerOptionList = new ArrayList<>();
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/cmc/suppin/event/survey/domain/Question.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/Question.java
@@ -25,9 +25,11 @@ public class Question {
     private Survey survey;
 
     @OneToMany(mappedBy = "question")
+    @Builder.Default
     private List<QuestionOption> questionOptionList = new ArrayList<>();
 
     @OneToMany(mappedBy = "question")
+    @Builder.Default
     private List<Answer> answerList = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/cmc/suppin/event/survey/domain/QuestionOption.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/QuestionOption.java
@@ -27,6 +27,7 @@ public class QuestionOption {
     private String optionText;
 
     @OneToMany(mappedBy = "questionOption")
+    @Builder.Default
     private List<AnswerOption> answerOptionList = new ArrayList<>();
 
 }

--- a/src/main/java/com/cmc/suppin/event/survey/domain/Survey.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/Survey.java
@@ -26,12 +26,15 @@ public class Survey extends BaseDateTimeEntity {
     private Event event;
 
     @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<PersonalInfoCollectOption> personalInfoList = new ArrayList<>();
 
     @OneToMany(mappedBy = "survey")
+    @Builder.Default
     private List<Question> questionList = new ArrayList<>();
 
     @OneToMany(mappedBy = "survey")
+    @Builder.Default
     private List<AnonymousParticipant> anonymousParticipantList = new ArrayList<>();
 
     @Column(columnDefinition = "TEXT")
@@ -39,5 +42,8 @@ public class Survey extends BaseDateTimeEntity {
 
     @Column(nullable = false, updatable = false, unique = true)
     private String uuid;
+
+    @Column(columnDefinition = "TEXT")
+    private String consentFormHtml;
 }
 

--- a/src/main/java/com/cmc/suppin/event/survey/domain/repository/AnonymousParticipantRepository.java
+++ b/src/main/java/com/cmc/suppin/event/survey/domain/repository/AnonymousParticipantRepository.java
@@ -1,6 +1,7 @@
 package com.cmc.suppin.event.survey.domain.repository;
 
 import com.cmc.suppin.event.survey.domain.AnonymousParticipant;
+import com.cmc.suppin.event.survey.domain.Survey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -13,4 +14,5 @@ public interface AnonymousParticipantRepository extends JpaRepository<AnonymousP
 
     List<AnonymousParticipant> findBySurveyIdAndIsWinnerTrue(Long surveyId);
 
+    List<AnonymousParticipant> findBySurveyAndIsWinnerTrue(Survey survey);
 }

--- a/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
+++ b/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
@@ -231,4 +231,19 @@ public class SurveyService {
             anonymousParticipantRepository.save(participant);
         }
     }
+
+    public List<SurveyResponseDTO.SurveyEventWinners> getSurveyEventWinners(Long surveyId, String userId) {
+        Member member = memberRepository.findByUserIdAndStatusNot(userId, UserStatus.DELETED)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        Survey survey = surveyRepository.findById(surveyId)
+                .orElseThrow(() -> new IllegalArgumentException("Survey not found"));
+
+        List<AnonymousParticipant> winners = anonymousParticipantRepository.findBySurveyAndIsWinnerTrue(survey);
+
+        return winners.stream()
+                .map(SurveyConverter::toSurveyEventWinners)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
+++ b/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
@@ -54,7 +54,7 @@ public class SurveyService {
 
         // Survey 엔티티 생성 및 저장
         String uuid = UUID.randomUUID().toString();
-        Survey survey = SurveyConverter.toSurveyEntity(event, uuid);
+        Survey survey = SurveyConverter.toSurveyEntity(event, uuid, request.getConsentFormHtml());
         surveyRepository.save(survey);
 
         // 각 개인정보 항목 처리 및 저장

--- a/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
+++ b/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -172,8 +174,10 @@ public class SurveyService {
                 .collect(Collectors.toList());
 
         // 조건에 맞는 주관식 답변 조회
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy. MM. dd HH:mm");
+
         List<Answer> eligibleAnswers = answerCustomRepository.findEligibleAnswers(
-                request.getQuestionId(), request.getStartDate(), request.getEndDate(),
+                request.getQuestionId(), LocalDateTime.parse(request.getStartDate(), formatter), LocalDateTime.parse(request.getEndDate(), formatter),
                 request.getMinLength(), request.getKeywords());
 
         // 랜덤 추첨

--- a/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
+++ b/src/main/java/com/cmc/suppin/event/survey/service/SurveyService.java
@@ -84,7 +84,7 @@ public class SurveyService {
 
     // 생성된 설문지 조회
     @Transactional(readOnly = true)
-    public SurveyResponseDTO.SurveyResultDTO getSurvey(Long surveyId) {
+    public SurveyResponseDTO.SurveyResultDTO getSurveyBySurveyId(Long surveyId) {
         Survey survey = surveyRepository.findById(surveyId)
                 .orElseThrow(() -> new IllegalArgumentException("Survey not found"));
 

--- a/src/main/java/com/cmc/suppin/member/domain/Member.java
+++ b/src/main/java/com/cmc/suppin/member/domain/Member.java
@@ -25,6 +25,7 @@ public class Member extends BaseDateTimeEntity {
     private Long id;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Event> eventList = new ArrayList<>();
 
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
@@ -41,7 +42,7 @@ public class Member extends BaseDateTimeEntity {
 
     @Column(columnDefinition = "VARCHAR(13)", nullable = false)
     private String phoneNumber;
-    
+
     @Enumerated(EnumType.STRING)
     private UserRole role;
 


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
이벤트 관련 API 리팩토링-2

## ⏳ 작업 내용
- [x] 이벤트 관련 API 응답값 수정
- [x] 홈화면에서 당첨자 간편 조회할 수 있도록 추가 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
당첨자 확정에 대한 트리거 필요(기획 나오면 재정의 필요)

